### PR TITLE
Enhance FinLab static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,38 @@
-# FinLab
-Crea un sito web responsive, moderno e pulito per una piccola azienda italiana chiamata **FinLab**, situata a **Permignano, nelle Marche (Italia)**. L’azienda produce **bancali e casse in legno** su misura per altri business (no privati), destinati al **trasporto merci industriale**.
+# FinLab Website
 
-Il sito deve avere uno stile minimalista e professionale, ispirato al design di aziende come Apple o Tesla, ma con colori, texture o sfondi che **richiamano il legno naturale**. Tutto deve essere semplice, elegante, senza distrazioni, con font leggibili e layout ordinato.
+Questo repository contiene un semplice sito web statico per l'azienda **FinLab**, produttrice di bancali e casse in legno su misura a Fermignano (PU).
 
-### 📁 Struttura del sito
+Il sito &egrave; realizzato con [Tailwind CSS](https://tailwindcss.com) tramite CDN e pu&ograve; essere modificato rapidamente lavorando sui file HTML.
 
-#### 1. Homepage (`index.html`)
-- Logo FinLab in alto a sinistra (placeholder se non disponibile)
-- Hero section con:
-  - Titolo: `Soluzioni in legno per il trasporto industriale`
-  - Sottotitolo: `Dal cuore delle Marche, bancali e casse in legno su misura per la logistica aziendale`
-  - Bottone: “Scopri di più” che scrolla alla sezione successiva
-- Sezione video aziendale (usa un placeholder per ora)
-- Sezione con 3 punti di forza:
-  - **Affidabilità artigianale**
-  - **Produzione su misura**
-  - **Solo per aziende**
+## Struttura
 
-#### 2. Chi siamo (`about.html`)
-- Storia di FinLab:
-  > Fondata a Permignano, FinLab è un’azienda familiare con oltre 20 anni di esperienza nella produzione di bancali e casse in legno. Specializzati in soluzioni personalizzate per la logistica, serviamo solo aziende in cerca di qualità, solidità e puntualità.
-- Filosofia aziendale: serietà, precisione, sostenibilità del legno
+- `index.html` – homepage con sezione hero, video aziendale e punti di forza.
+- `about.html` – storia dell'azienda e filosofia.
+- `services.html` – descrizione dei prodotti e della lavorazione.
+- `contact.html` – recapiti e form di contatto.
+- `assets/img/` – immagini (attualmente sono presenti placeholder da sostituire).
+- `assets/video/` – video aziendale (placeholder `placeholder.mp4`).
+- `style.css` – piccole personalizzazioni aggiuntive (body beige e testo scuro).
 
-#### 3. Cosa facciamo (`services.html`)
-- Breve introduzione: “Ogni azienda ha esigenze diverse. FinLab crea bancali e casse in legno su misura, con assi di diverse dimensioni e configurazioni.”
-- Lista prodotti:
-  - Bancali standard e su misura
-  - Casse in legno chiuse o aperte
-  - Imballaggi resistenti per trasporti nazionali e internazionali
-- Nota importante: “Lavoriamo esclusivamente con aziende e operatori del settore logistico e trasporti. Non vendiamo a privati.”
+## Personalizzazione
 
-#### 4. Contatti (`contact.html`)
-- Indirizzo: FinLab Srl, Permignano (MC), Italia
-- Email: `info@finlab.it` (placeholder)
-- Telefono: `+39 000 0000000` (placeholder)
-- Mappa Google (placeholder iframe)
-- Form contatto: nome, email, messaggio
+1. **Logo e immagini**
+   - Sostituisci `assets/img/placeholder.jpg` con il tuo logo e altre immagini. Mantieni lo stesso nome file oppure aggiorna il percorso nei tag `<img>` e nel CSS.
+   - Per cambiare l'immagine di sfondo dell'hero in `index.html`, modifica l'URL nello stile inline del relativo `<section>`.
 
-### 🎨 Design
-- Usa **Tailwind CSS** per uno stile pulito e responsive
-- Colori principali: bianco, beige chiaro, marrone legno (soft, non troppo scuro)
-- Font: sans-serif moderno (es. Inter, Roboto, o SF Pro)
-- Immagini placeholder per ora (dove poi caricheremo quelle reali)
+2. **Video aziendale**
+   - Rimpiazza `assets/video/placeholder.mp4` con il tuo video. Assicurati di mantenere l'estensione `.mp4` o aggiorna il tag `<source>` in `index.html`.
 
-### 📁 File richiesti
-- `index.html`, `about.html`, `services.html`, `contact.html`
-- `/assets/img/` per immagini (placeholder)
-- `/assets/video/` per video aziendale (placeholder)
-- `style.css` solo per override minimi se serve
+3. **Testi**
+   - Tutti i testi si trovano direttamente nei file HTML. Apri il file che ti interessa e modifica il contenuto tra i tag.
 
-### 📝 README.md
-Aggiungi istruzioni su:
-- Dove inserire logo, immagini e video
-- Come modificare i testi
-- Come cambiare contatti
+4. **Contatti**
+   - Aggiorna indirizzo, email e telefono in `contact.html` modificando i rispettivi paragrafi.
+   - L'iframe della mappa pu&ograve; essere sostituito con il codice fornito da Google Maps o da un altro servizio.
 
-Commenta bene tutto il codice HTML e CSS, così da facilitare modifiche future.
+5. **Stile**
+   - `style.css` contiene solo poche regole di base. Puoi ampliarlo aggiungendo nuove classi o utilizzando l'utility `@apply` di Tailwind se hai un processo di build dedicato.
 
-NON includere e-commerce, login o pagamenti.
+## Note
 
+Il sito &egrave; pensato per aziende del settore logistico e **non** include funzionalit&agrave; di e-commerce o autenticazione. Tutto il codice HTML &egrave; commentato per facilitare eventuali modifiche.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinLab - Chi siamo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="font-sans">
+    <!-- Header reused on all pages -->
+    <header class="bg-white bg-opacity-80 backdrop-blur sticky top-0 z-10 shadow-sm">
+        <div class="container mx-auto px-4 py-2 flex items-center">
+            <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
+            <span class="text-xl font-semibold">FinLab</span>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 py-16">
+        <!-- About section with history -->
+        <h1 class="text-3xl font-semibold mb-6">Chi siamo</h1>
+        <p class="mb-4">Fondata a Fermignano, FinLab &egrave; un&rsquo;azienda familiare con oltre 20 anni di esperienza nella produzione di bancali e casse in legno. Specializzati in soluzioni personalizzate per la logistica, serviamo solo aziende in cerca di qualit&agrave;, solidit&agrave; e puntualit&agrave;.</p>
+        <p>La nostra filosofia unisce seriet&agrave;, precisione e attenzione alla sostenibilit&agrave; del legno per garantire prodotti affidabili e duraturi.</p>
+    </main>
+
+    <footer class="bg-white bg-opacity-80 py-4 text-center">
+        <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
+        <nav class="mt-2 space-x-4">
+            <a href="index.html" class="hover:underline">Home</a>
+            <a href="about.html" class="hover:underline">Chi siamo</a>
+            <a href="services.html" class="hover:underline">Cosa facciamo</a>
+            <a href="contact.html" class="hover:underline">Contatti</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/assets/img/finlab-logo.jpg
+++ b/assets/img/finlab-logo.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/assets/img/placeholder.jpg
+++ b/assets/img/placeholder.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/assets/video/placeholder.mp4
+++ b/assets/video/placeholder.mp4
@@ -1,0 +1,1 @@
+placeholder video

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinLab - Contatti</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="font-sans">
+    <!-- Header with navigation -->
+    <header class="bg-white bg-opacity-80 backdrop-blur sticky top-0 z-10 shadow-sm">
+        <div class="container mx-auto px-4 py-2 flex items-center">
+            <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
+            <span class="text-xl font-semibold">FinLab</span>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 py-16">
+        <!-- Contact information -->
+        <h1 class="text-3xl font-semibold mb-6">Contatti</h1>
+        <p class="mb-2">Indirizzo: FinLab Srl, Fermignano (PU), Italia</p>
+        <p class="mb-2">Email: <a href="mailto:info@finlab.it" class="text-blue-600 hover:underline">info@finlab.it</a></p>
+        <p class="mb-6">Telefono: <a href="tel:+390000000000" class="text-blue-600 hover:underline">+39 000 0000000</a></p>
+
+        <!-- Google map placeholder -->
+        <div class="mb-8">
+            <iframe src="https://maps.google.com" class="w-full h-64 rounded" allowfullscreen loading="lazy"></iframe>
+        </div>
+
+        <!-- Simple contact form -->
+        <form class="grid grid-cols-1 gap-4" action="#" method="post">
+            <input type="text" name="nome" placeholder="Nome" class="p-2 border rounded" required>
+            <input type="email" name="email" placeholder="Email" class="p-2 border rounded" required>
+            <textarea name="messaggio" rows="5" placeholder="Messaggio" class="p-2 border rounded" required></textarea>
+            <button type="submit" class="bg-yellow-700 text-white px-4 py-2 rounded hover:bg-yellow-800">Invia</button>
+        </form>
+    </main>
+
+    <footer class="bg-white bg-opacity-80 py-4 text-center">
+        <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
+        <nav class="mt-2 space-x-4">
+            <a href="index.html" class="hover:underline">Home</a>
+            <a href="about.html" class="hover:underline">Chi siamo</a>
+            <a href="services.html" class="hover:underline">Cosa facciamo</a>
+            <a href="contact.html" class="hover:underline">Contatti</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -21,16 +21,16 @@
         </div>
     </header>
 
-    <!-- Hero section with wood background -->
-    <section class="min-h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=1350&q=80');">
+    <!-- Hero section with wood background (replace image URL if needed) -->
+    <section class="min-h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('https://images.unsplash.com/photo-1508612761958-bd6a8977f696?auto=format&fit=crop&w=1350&q=80');">
         <div class="section-box text-center fade-up">
             <h1 class="text-4xl md:text-6xl font-bold mb-4">Soluzioni in legno per il trasporto industriale</h1>
             <p class="text-lg md:text-2xl mb-8">Dal cuore delle Marche, bancali e casse in legno su misura per la logistica aziendale</p>
-            <a href="#video" class="inline-block bg-yellow-700 text-white px-6 py-3 rounded shadow transition transform hover:bg-yellow-800 hover:scale-105">Scopri di più</a>
+            <a href="#video" class="inline-block bg-amber-700 text-white px-6 py-3 rounded shadow transition transform hover:bg-amber-800 hover:scale-105">Scopri di più</a>
         </div>
     </section>
 
-    <!-- Video section -->
+    <!-- Video section with placeholder -->
     <section id="video" class="container mx-auto px-4 py-16 fade-up">
         <div class="section-box">
             <h2 class="text-3xl font-semibold text-center mb-8">Video aziendale</h2>
@@ -42,25 +42,25 @@
         </div>
     </section>
 
-    <!-- Strengths section -->
+    <!-- Strengths section with 3-column grid -->
     <section class="py-16 fade-up">
         <div class="container mx-auto px-4 section-box">
             <div class="text-center grid grid-cols-1 md:grid-cols-3 gap-8">
                 <!-- Affidabilità artigianale -->
                 <div class="p-4">
-                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                    <svg class="mx-auto h-12 w-12 text-amber-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                     <h3 class="text-xl font-semibold mb-2">Affidabilit&agrave; artigianale</h3>
                     <p>Realizziamo prodotti curati con attenzione ai dettagli e materiali di qualit&agrave;.</p>
                 </div>
                 <!-- Produzione su misura -->
                 <div class="p-4">
-                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 6h18M3 14h18M3 18h18"></path></svg>
+                    <svg class="mx-auto h-12 w-12 text-amber-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 6h18M3 14h18M3 18h18"></path></svg>
                     <h3 class="text-xl font-semibold mb-2">Produzione su misura</h3>
                     <p>Ogni bancale e cassa &egrave; progettato secondo le specifiche esigenze della tua azienda.</p>
                 </div>
                 <!-- Solo per aziende -->
                 <div class="p-4">
-                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0-2.21 1.79-4 4-4s4 1.79 4 4v4h1a1 1 0 0 1 1 1v5H3v-5a1 1 0 0 1 1-1h1v-4c0-2.21 1.79-4 4-4s4 1.79 4 4z"></path></svg>
+                    <svg class="mx-auto h-12 w-12 text-amber-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0-2.21 1.79-4 4-4s4 1.79 4 4v4h1a1 1 0 0 1 1 1v5H3v-5a1 1 0 0 1 1-1h1v-4c0-2.21 1.79-4 4-4s4 1.79 4 4z"></path></svg>
                     <h3 class="text-xl font-semibold mb-2">Solo per aziende</h3>
                     <p>Collaboriamo esclusivamente con realt&agrave; professionali e operatori della logistica.</p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinLab - Soluzioni in legno per il trasporto industriale</title>
+    <!-- Tailwind CSS via CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Inter font -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <!-- Custom styles -->
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <!-- Fixed transparent header with glassmorphism -->
+    <header class="fixed top-0 left-0 w-full bg-white/30 backdrop-blur-md shadow-lg z-50">
+        <div class="container mx-auto px-4 py-2 flex items-center">
+            <!-- Company logo -->
+            <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
+            <span class="text-xl font-semibold">FinLab</span>
+        </div>
+    </header>
+
+    <!-- Hero section with wood background -->
+    <section class="min-h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=1350&q=80');">
+        <div class="section-box text-center fade-up">
+            <h1 class="text-4xl md:text-6xl font-bold mb-4">Soluzioni in legno per il trasporto industriale</h1>
+            <p class="text-lg md:text-2xl mb-8">Dal cuore delle Marche, bancali e casse in legno su misura per la logistica aziendale</p>
+            <a href="#video" class="inline-block bg-yellow-700 text-white px-6 py-3 rounded shadow transition transform hover:bg-yellow-800 hover:scale-105">Scopri di più</a>
+        </div>
+    </section>
+
+    <!-- Video section -->
+    <section id="video" class="container mx-auto px-4 py-16 fade-up">
+        <div class="section-box">
+            <h2 class="text-3xl font-semibold text-center mb-8">Video aziendale</h2>
+            <!-- Replace the video src with your actual video file -->
+            <video controls class="w-full rounded" poster="assets/img/placeholder.jpg">
+                <source src="assets/video/placeholder.mp4" type="video/mp4">
+                Il tuo browser non supporta i video HTML5.
+            </video>
+        </div>
+    </section>
+
+    <!-- Strengths section -->
+    <section class="py-16 fade-up">
+        <div class="container mx-auto px-4 section-box">
+            <div class="text-center grid grid-cols-1 md:grid-cols-3 gap-8">
+                <!-- Affidabilità artigianale -->
+                <div class="p-4">
+                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                    <h3 class="text-xl font-semibold mb-2">Affidabilit&agrave; artigianale</h3>
+                    <p>Realizziamo prodotti curati con attenzione ai dettagli e materiali di qualit&agrave;.</p>
+                </div>
+                <!-- Produzione su misura -->
+                <div class="p-4">
+                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 6h18M3 14h18M3 18h18"></path></svg>
+                    <h3 class="text-xl font-semibold mb-2">Produzione su misura</h3>
+                    <p>Ogni bancale e cassa &egrave; progettato secondo le specifiche esigenze della tua azienda.</p>
+                </div>
+                <!-- Solo per aziende -->
+                <div class="p-4">
+                    <svg class="mx-auto h-12 w-12 text-yellow-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0-2.21 1.79-4 4-4s4 1.79 4 4v4h1a1 1 0 0 1 1 1v5H3v-5a1 1 0 0 1 1-1h1v-4c0-2.21 1.79-4 4-4s4 1.79 4 4z"></path></svg>
+                    <h3 class="text-xl font-semibold mb-2">Solo per aziende</h3>
+                    <p>Collaboriamo esclusivamente con realt&agrave; professionali e operatori della logistica.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer with minimal info and navigation -->
+    <footer class="bg-white bg-opacity-80 py-4 text-center">
+        <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
+        <nav class="mt-2 space-x-4">
+            <a href="index.html" class="hover:underline">Home</a>
+            <a href="about.html" class="hover:underline">Chi siamo</a>
+            <a href="services.html" class="hover:underline">Cosa facciamo</a>
+            <a href="contact.html" class="hover:underline">Contatti</a>
+        </nav>
+    </footer>
+
+    <!-- Fade-in animation for sections -->
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('appear');
+                    }
+                });
+            }, { threshold: 0.1 });
+            document.querySelectorAll('.fade-up').forEach(el => observer.observe(el));
+        });
+    </script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinLab - Cosa facciamo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="font-sans">
+    <!-- Common header -->
+    <header class="bg-white bg-opacity-80 backdrop-blur sticky top-0 z-10 shadow-sm">
+        <div class="container mx-auto px-4 py-2 flex items-center">
+            <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
+            <span class="text-xl font-semibold">FinLab</span>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 py-16">
+        <!-- Services introduction -->
+        <h1 class="text-3xl font-semibold mb-6">Cosa facciamo</h1>
+        <p class="mb-6">Ogni azienda ha esigenze diverse. FinLab crea bancali e casse in legno su misura, con assi di diverse dimensioni e configurazioni.</p>
+
+        <ul class="list-disc list-inside space-y-2 mb-6">
+            <li>Bancali standard e su misura</li>
+            <li>Casse in legno chiuse o aperte</li>
+            <li>Imballaggi resistenti per trasporti nazionali e internazionali</li>
+        </ul>
+
+        <p class="font-semibold">Lavoriamo esclusivamente con aziende e operatori del settore logistico e trasporti. Non vendiamo a privati.</p>
+    </main>
+
+    <footer class="bg-white bg-opacity-80 py-4 text-center">
+        <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
+        <nav class="mt-2 space-x-4">
+            <a href="index.html" class="hover:underline">Home</a>
+            <a href="about.html" class="hover:underline">Chi siamo</a>
+            <a href="services.html" class="hover:underline">Cosa facciamo</a>
+            <a href="contact.html" class="hover:underline">Contatti</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -5,9 +5,9 @@ html {
   scroll-behavior: smooth;
 }
 
-/* Global body styles: light wood background and Inter font */
+/* Global body styles: light wood texture (update URL if needed) and Inter font */
 body {
-  background-image: url('https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1350&q=80');
+  background-image: url('https://images.unsplash.com/photo-1598203634571-3f3c05658d26?auto=format&fit=crop&w=1350&q=80');
   background-size: cover;
   background-attachment: fixed;
   background-position: center;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+/* style.css - custom styles for the FinLab website */
+
+/* Enable smooth scrolling for anchor links */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Global body styles: light wood background and Inter font */
+body {
+  background-image: url('https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-attachment: fixed;
+  background-position: center;
+  font-family: 'Inter', sans-serif;
+  color: #1f2937; /* gray-800 */
+}
+
+/* Reusable box style for semi-transparent sections */
+.section-box {
+  background-color: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  padding: 2rem;
+  border-radius: 0.5rem; /* rounded */
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Fade up animation used when sections enter the viewport */
+.fade-up {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.8s ease-out, transform 0.8s ease-out;
+}
+
+.fade-up.appear {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- modernise homepage with wood texture, glassy navbar and smooth scroll
- add semi-transparent section boxes and fade animations
- update company location and copyright
- use new `finlab-logo.jpg` across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c063e8100832ab11eff11c289622a