### PR TITLE
Improve dark mode styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,8 +16,8 @@
     <header class="bg-white/40 dark:bg-black/40 backdrop-blur sticky top-0 z-10 shadow-sm">
         <div class="container mx-auto px-4 py-2 flex items-center justify-between">
             <div class="flex items-center">
-                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
-                <span class="text-xl font-semibold">FinLab</span>
+                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4 dark:invert">
+                <span class="text-xl font-semibold dark:text-gray-200">FinLab</span>
             </div>
             <button id="theme-toggle" class="text-xl"></button>
         </div>
@@ -30,7 +30,7 @@
         <p class="dark:text-gray-100">La nostra filosofia unisce seriet&agrave;, precisione e attenzione alla sostenibilit&agrave; del legno per garantire prodotti affidabili e duraturi.</p>
     </main>
 
-    <footer class="bg-white/40 dark:bg-black/40 py-4 text-center">
+    <footer class="bg-white/40 py-4 text-center dark:bg-gray-900 dark:text-white">
         <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
         <nav class="mt-2 space-x-4 dark:text-gray-200">
             <a href="index.html" class="hover:underline">Home</a>

--- a/contact.html
+++ b/contact.html
@@ -16,8 +16,8 @@
     <header class="bg-white/40 dark:bg-black/40 backdrop-blur sticky top-0 z-10 shadow-sm">
         <div class="container mx-auto px-4 py-2 flex items-center justify-between">
             <div class="flex items-center">
-                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
-                <span class="text-xl font-semibold">FinLab</span>
+                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4 dark:invert">
+                <span class="text-xl font-semibold dark:text-gray-200">FinLab</span>
             </div>
             <button id="theme-toggle" class="text-xl"></button>
         </div>
@@ -44,7 +44,7 @@
         </form>
     </main>
 
-    <footer class="bg-white/40 dark:bg-black/40 py-4 text-center">
+    <footer class="bg-white/40 py-4 text-center dark:bg-gray-900 dark:text-white">
         <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
         <nav class="mt-2 space-x-4 dark:text-gray-200">
             <a href="index.html" class="hover:underline">Home</a>

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
         <div class="container mx-auto px-4 py-3 flex items-center justify-between">
             <div class="flex items-center">
                 <!-- Company logo -->
-                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-3">
-                <span class="text-xl font-semibold">FinLab</span>
+                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-3 dark:invert">
+                <span class="text-xl font-semibold dark:text-gray-200">FinLab</span>
             </div>
             <div class="flex items-center space-x-4">
                 <!-- Navigation links -->
@@ -109,9 +109,9 @@
     </section>
 
     <!-- Footer with minimal info and navigation -->
-    <footer class="bg-white/40 dark:bg-black/40 backdrop-blur-lg py-4 text-center fade-slide">
+    <footer class="bg-white/40 backdrop-blur-lg py-4 text-center fade-slide dark:bg-gray-900 dark:text-white">
         <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
-        <nav class="mt-2 space-x-4">
+        <nav class="mt-2 space-x-4 dark:text-gray-200">
             <a href="index.html" class="hover:underline">Home</a>
             <a href="about.html" class="hover:underline">Chi siamo</a>
             <a href="services.html" class="hover:underline">Cosa facciamo</a>

--- a/services.html
+++ b/services.html
@@ -16,8 +16,8 @@
     <header class="bg-white/40 dark:bg-black/40 backdrop-blur sticky top-0 z-10 shadow-sm">
         <div class="container mx-auto px-4 py-2 flex items-center justify-between">
             <div class="flex items-center">
-                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4">
-                <span class="text-xl font-semibold">FinLab</span>
+                <img src="assets/img/finlab-logo.jpg" alt="FinLab logo" class="h-10 mr-4 dark:invert">
+                <span class="text-xl font-semibold dark:text-gray-200">FinLab</span>
             </div>
             <button id="theme-toggle" class="text-xl"></button>
         </div>
@@ -36,7 +36,7 @@
 
     </main>
 
-    <footer class="bg-white/40 dark:bg-black/40 py-4 text-center">
+    <footer class="bg-white/40 py-4 text-center dark:bg-gray-900 dark:text-white">
         <p class="text-sm">&copy; 2025 FinLab - Fermignano (PU), Italia</p>
         <nav class="mt-2 space-x-4 dark:text-gray-200">
             <a href="index.html" class="hover:underline">Home</a>

--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ html.dark body {
 
 /* Variante dark della translucent box */
 html.dark .translucent-box {
-  background-color: rgba(0, 0, 0, 0.4); /* bg-black/40 */
+  background-color: rgba(17, 24, 39, 0.5); /* gray-900/50 */
 }
 
 /* Fade and slide animation for section reveal */


### PR DESCRIPTION
## Summary
- tweak translucent box dark color
- ensure logo and brand text contrast in dark mode
- update footers to use solid dark background
- keep toggle script for consistent behaviour on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d3fcaa15c832a9b586f64d35e059d